### PR TITLE
Dashboard and Chart bugfixes - part 2

### DIFF
--- a/src/frontend/components/dashboards/AllCharts.jsx
+++ b/src/frontend/components/dashboards/AllCharts.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef, useMemo } from 'react';
 import Icon from "../common/Icon.jsx";
 import { apiFetch, runQuery } from '../../utils/api.js';
 import { findParameters, hasValue } from '../../../shared/sqlParams.js';
-import { buildChartOption } from './chartTypes.js';
+import { buildChartOption, needsLegend } from './chartTypes.js';
 import { initChart, disposeChart, withZoomable } from '../../utils/echarts.js';
 import ChartToolbar, { useChartTools } from '../common/ChartToolbar.jsx';
 import DataTable from '../layout/DataTable.jsx';
@@ -31,16 +31,6 @@ export default function AllCharts({ onEdit }) {
   const { theme } = useTheme()
 
   const isDarkColor = theme === 'dark' ? 'white' : 'black';
-
-  const legendSupportedTypes = [
-    'grouped_bar', 'stacked_bar', 
-    'multi_line', 'stacked_line',
-    'pie', 'donut', 'rose', 'nested_pie',
-    'bubble',
-    'multi_category',
-    'funnel',
-    'radar'
-  ];
 
   useEffect(() => {
     const handleResize = () => setIsSmallScreen(window.innerWidth <= 768);
@@ -105,7 +95,7 @@ export default function AllCharts({ onEdit }) {
     return series.some(s => Array.isArray(s?.data) && s?.data.length > 0);
   }, [previewOpt]);
 
-  const supportsLegend = selected && legendSupportedTypes.includes(selected.chartSubtype);
+  const supportsLegend = selected && needsLegend(selected.chartType, selected.chartSubtype);
 
   useEffect(() => {
     if (!previewRef.current || !previewOpt || previewOpt._kpi || previewOpt._table || previewOpt._error) {
@@ -135,7 +125,7 @@ export default function AllCharts({ onEdit }) {
 
       const extraLeftForYAxisName = yHasName ? 60 : 20;
 
-      const barChartTypes = ['simple_bar', 'grouped_bar', 'stacked_bar'];
+      const barChartTypes = ['simple_bar', 'grouped_bar', 'stacked_bar', 'horizontal_bar'];
       const isBarChart = barChartTypes.includes(selected?.chartSubtype);
       const isScatterLike = selected?.chartSubtype === 'scatter' || selected?.chartSubtype === 'basic_scatter' || selected?.chartSubtype === 'bubble' || selected?.chartType === 'scatter' || selected?.chartType === 'bubble';
       const pieChartTypes = ['pie', 'donut', 'rose', 'nested_pie'];

--- a/src/frontend/components/dashboards/ChartBuilder.jsx
+++ b/src/frontend/components/dashboards/ChartBuilder.jsx
@@ -133,19 +133,9 @@ export default function ChartBuilder({ editChart, onEditDone }) {
     (s) => s.subtype === chartSubtype,
   );
   const fields = subtypeInfo?.fields || [];
-  const hasAxisLabels = typeInfo?.hasXLabel || chartType === "boxplot" || false;
+  const hasAxisLabels = typeInfo?.hasXLabel || false;
   
-  const legendSupportedTypes = [
-    'grouped_bar', 'stacked_bar', 
-    'multi_line', 'stacked_line',
-    'pie', 'donut', 'rose', 'nested_pie',
-    'bubble',
-    'multi_category',
-    'funnel',
-    'radar'
-  ];
-  
-  const shouldShowLegend = legendSupportedTypes.includes(chartSubtype) && needsLegend(chartType, chartSubtype);
+  const shouldShowLegend = needsLegend(chartType, chartSubtype);
 
   useEffect(() => {
     if (!editChart) {
@@ -225,10 +215,17 @@ export default function ChartBuilder({ editChart, onEditDone }) {
       return;
     }
     try {
+      let effectiveXLabel = xLabel;
+      let effectiveYLabel = yLabel;
+      if (chartSubtype === "horizontal_bar") {
+        effectiveXLabel = yLabel;
+        effectiveYLabel = xLabel;
+      }
+      
       setChartOption(
         buildChartOption(chartType, chartSubtype, data, mapping, chartName, {
-          xLabel,
-          yLabel,
+          xLabel: effectiveXLabel,
+          yLabel: effectiveYLabel,
           showLegend: shouldShowLegend ? showLegend : false,
         }),
       );
@@ -270,7 +267,7 @@ export default function ChartBuilder({ editChart, onEditDone }) {
       const hasLegendCheck = chartOption.legend?.show || (Array.isArray(chartOption.series) && chartOption.series.some(s => Array.isArray(s?.data) && s?.data.length > 0));
       const legendVisible = shouldShowLegend && showLegend;
 
-      const barChartTypes = ['simple_bar', 'grouped_bar', 'stacked_bar'];
+      const barChartTypes = ['simple_bar', 'grouped_bar', 'stacked_bar', 'horizontal_bar'];
       const isBarChart = barChartTypes.includes(chartSubtype);
       const isScatterLike = chartSubtype === 'scatter' || chartSubtype === 'basic_scatter' || chartSubtype === 'bubble' || chartType === 'scatter' || chartType === 'bubble';
       const pieChartTypes = ['pie', 'donut', 'rose', 'nested_pie'];
@@ -1808,4 +1805,3 @@ export default function ChartBuilder({ editChart, onEditDone }) {
     </div>
   );
 }
-

--- a/src/frontend/components/dashboards/chartTypes.js
+++ b/src/frontend/components/dashboards/chartTypes.js
@@ -297,6 +297,7 @@ export const CHART_TYPES = [
   {
     type: "funnel",
     label: "Funnel",
+    hasLegend: true,
     subtypes: [
       {
         subtype: "standard",
@@ -1026,6 +1027,7 @@ export function buildChartOption(
       return {
         tooltip: { trigger: "item", formatter: "{b}: {c}" },
         toolbox,
+        legend,
         series: [
           {
             type: "funnel",

--- a/src/frontend/utils/pageHeaders.generated.js
+++ b/src/frontend/utils/pageHeaders.generated.js
@@ -127,6 +127,18 @@ export const PAGE_TEXT = {
     "Merges",
     "Mutations",
     "Readonly Tables",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG",
     "Node",
     "Cluster topology",
     "Loading topology...",
@@ -160,7 +172,18 @@ export const PAGE_TEXT = {
     "Total Written",
     "Query errors + critical/fatal system log entries",
     "Query Errors",
-    "Critical / Fatal"
+    "Critical / Fatal",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions"
   ],
   "overview/queries": [
     "Click to view query",
@@ -193,6 +216,18 @@ export const PAGE_TEXT = {
     "From (required)",
     "To (required)",
     "partial...",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG",
     "Open in...",
     "All users",
     "All kinds",
@@ -218,7 +253,6 @@ export const PAGE_TEXT = {
     "Memory",
     "Longest",
     "Read",
-    "Actions",
     "Query detail",
     "Cancellation requested. The query is winding down.",
     "Loading full text...",
@@ -272,7 +306,19 @@ export const PAGE_TEXT = {
     "Active Parts",
     "Inactive Parts",
     "Detached Parts",
-    "Broken Parts"
+    "Broken Parts",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG",
+    "Generated SQL"
   ],
   "overview/operations": [
     "Loading...",
@@ -280,7 +326,15 @@ export const PAGE_TEXT = {
     "Mutations",
     "Replication Queue",
     "Active Merges",
-    "Active Mutations"
+    "Active Mutations",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Generated SQL",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions"
   ],
   "overview/ddl": [
     "Loading...",
@@ -291,9 +345,18 @@ export const PAGE_TEXT = {
     "(auto-refresh 30s)",
     "DDL Queue Length",
     "Median Processing Time",
-    "Failed DDLs"
+    "Failed DDLs",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Generated SQL",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions"
   ],
   "overview/queues": [
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
     "Loading ingestion data...",
     "By error code",
     "All failures",
@@ -301,14 +364,28 @@ export const PAGE_TEXT = {
     "Search files",
     "File name contains",
     "Exception contains",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG",
     "Loading queue state...",
     "Executing",
     "With errors",
     "Filter tasks...",
-    "Nothing pending."
+    "Nothing pending.",
+    "Something went wrong",
+    "Try Again"
   ],
   "overview/kubernetes": [
     "Loading...",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "No options",
     "readiness unknown",
     "Troubleshoot mode is on.",
     "Hosts are running different versions.",
@@ -403,6 +480,14 @@ export const PAGE_TEXT = {
     "Resize the SQL editor",
     "Bookmark name",
     "Download PNG",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
     "Analyzing query...",
     "Cost Estimate",
     "Database",
@@ -508,7 +593,12 @@ export const PAGE_TEXT = {
     "Generate Flame Graph",
     "to visualize execution.",
     "View Generated SQL",
-    "Reset zoom"
+    "Reset zoom",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Zoom in",
+    "Zoom out",
+    "Save PNG"
   ],
   "tools/pipeline": [
     "Processor Details",
@@ -523,7 +613,9 @@ export const PAGE_TEXT = {
     "Refreshing options...",
     "Query text (click to expand)",
     "Loading pipeline graph...",
-    "Select a query above to visualize its execution pipeline"
+    "Select a query above to visualize its execution pipeline",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the"
   ],
   "tools/metrics": [
     "Query Details",
@@ -540,7 +632,12 @@ export const PAGE_TEXT = {
     "Clear",
     "Select a query and click",
     "Show Query Metrics",
-    "to visualize its resource usage over time."
+    "to visualize its resource usage over time.",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG"
   ],
   "tools/qurioz": [
     "Database Schema Generator",
@@ -548,6 +645,8 @@ export const PAGE_TEXT = {
     "Database Schema Generated",
     "Refresh Selected Schema",
     "Delete Schema's",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
     "Press Enter to send, Shift+Enter for new line.",
     "Search for query...",
     "Chat input",
@@ -559,6 +658,12 @@ export const PAGE_TEXT = {
     "Error occurs while executing the query",
     "Retry",
     "Chart View",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
     "Clickhouse Query",
     "Edit",
     "Copy",
@@ -575,7 +680,11 @@ export const PAGE_TEXT = {
     "Min",
     "Max",
     "Preview",
-    "Map columns to see preview."
+    "Map columns to see preview.",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG"
   ],
   "tools/schema-studio": [
     "Checking connection...",
@@ -585,6 +694,7 @@ export const PAGE_TEXT = {
     "ClickHouse user",
     "Password",
     "default",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
     "Upload a file",
     "Object storage",
     "Inferring schema...",
@@ -600,6 +710,7 @@ export const PAGE_TEXT = {
     "Secret access key",
     "Azure connection string",
     "Container",
+    "No options",
     "Review the inferred schema",
     "Column",
     "Type",
@@ -634,6 +745,7 @@ export const PAGE_TEXT = {
     "column or expression",
     "Remove projection",
     "SELECT country, count() GROUP BY country",
+    "Select...",
     "Use expression:",
     "Move earlier",
     "Move later",
@@ -671,7 +783,19 @@ export const PAGE_TEXT = {
     "Distinct Signals",
     "Crashed Versions",
     "Last Crash",
-    "partial..."
+    "partial...",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "No options",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG"
   ],
   "logs/error": [
     "Overview",
@@ -696,7 +820,19 @@ export const PAGE_TEXT = {
     "Error Types",
     "Remote Share",
     "Last Error",
-    "partial..."
+    "partial...",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "No options",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG"
   ],
   "logs/text": [
     "Overview",
@@ -720,7 +856,19 @@ export const PAGE_TEXT = {
     "Warnings",
     "Loggers",
     "Last Error",
-    "partial..."
+    "partial...",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "No options",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG"
   ],
   "logs/session": [
     "Overview",
@@ -747,12 +895,30 @@ export const PAGE_TEXT = {
     "Logouts",
     "Distinct Users",
     "Last Event",
-    "partial..."
+    "partial...",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "No options",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG"
   ],
   "monitoring/dashboards": [
     "Quick",
     "Rounding (s)",
-    "From"
+    "From",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG",
+    "No options"
   ],
   "monitoring/playback": [
     "User",
@@ -766,7 +932,19 @@ export const PAGE_TEXT = {
     "Select a time range and click",
     "Fetch Data",
     "to start.",
-    "From"
+    "From",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "No options",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions"
   ],
   "monitoring/allocator": [
     "Loading memory allocator stats...",
@@ -822,7 +1000,13 @@ export const PAGE_TEXT = {
     "Memory Efficiency",
     "Virtual Memory",
     "Reclaimable",
-    "Bookkeeping"
+    "Bookkeeping",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG"
   ],
   "alerting/rules": [
     "Alert rules management is only available for administrators.",
@@ -842,7 +1026,10 @@ export const PAGE_TEXT = {
     "Disabled",
     "FIRING",
     "NO NODES",
-    "NO CHANNELS"
+    "NO CHANNELS",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Cancel"
   ],
   "rbac/view": [
     "User Grants",
@@ -855,7 +1042,15 @@ export const PAGE_TEXT = {
     "Select a role.",
     "Users",
     "Roles",
-    "All Grants"
+    "All Grants",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions"
   ],
   "rbac/users": [
     "Loading...",
@@ -892,7 +1087,17 @@ export const PAGE_TEXT = {
     "Type the username",
     "to confirm:",
     "optional",
-    "var, ..."
+    "var, ...",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "Generated SQL",
+    "Cancel"
   ],
   "rbac/roles": [
     "Loading...",
@@ -916,7 +1121,17 @@ export const PAGE_TEXT = {
     "Role",
     "Drop",
     "Type the role name",
-    "to confirm:"
+    "to confirm:",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "Generated SQL",
+    "Cancel"
   ],
   "rbac/profiles": [
     "-- default --",
@@ -936,7 +1151,17 @@ export const PAGE_TEXT = {
     "Type the profile name",
     "to confirm:",
     "default",
-    "var1, var2"
+    "var1, var2",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "Generated SQL",
+    "Cancel"
   ],
   "indexes/visualizer": [
     "Failed to load schema",
@@ -959,7 +1184,9 @@ export const PAGE_TEXT = {
     "Fit",
     "CREATE Statement",
     "All connected tables across databases will be shown",
-    "Search table or column..."
+    "Search table or column...",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "No options"
   ],
   "indexes/secondary": [
     "Loading...",
@@ -967,7 +1194,9 @@ export const PAGE_TEXT = {
     "-- select --",
     "Table",
     "All",
-    "Download PNG"
+    "Download PNG",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the"
   ],
   "indexes/projections": [
     "-- select --",
@@ -987,7 +1216,11 @@ export const PAGE_TEXT = {
     "Clear Projection",
     "Download PNG",
     "col1, col2, sum(col3) - DISTINCT not supported in projections",
-    "col1, col2"
+    "col1, col2",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Generated SQL",
+    "Cancel",
+    "No options"
   ],
   "indexes/create": [
     "Create",
@@ -1024,7 +1257,10 @@ export const PAGE_TEXT = {
     "Materialize Index",
     "-- select --",
     "Drop Index",
-    "expression(str)"
+    "expression(str)",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Generated SQL"
   ],
   "custom/dashboards": [
     "Legends",
@@ -1034,6 +1270,8 @@ export const PAGE_TEXT = {
     "No charts. Use Chart Builder to add some.",
     "Drag charts to swap positions.",
     "Save Layout",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
     "This dashboard's filters cannot be built.",
     "Chart filters",
     "Out of date",
@@ -1050,7 +1288,17 @@ export const PAGE_TEXT = {
     "Cancel",
     "Save settings",
     "Close",
-    "Value:"
+    "Value:",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions"
   ],
   "backups/lifecycle": [
     "Loading...",
@@ -1089,7 +1337,10 @@ export const PAGE_TEXT = {
     "Retention",
     "INC",
     "FULL",
-    "Select a profile and click Scan S3 to discover backups."
+    "Select a profile and click Scan S3 to discover backups.",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Generated SQL"
   ],
   "admin/profiles": [
     "Type",
@@ -1100,7 +1351,9 @@ export const PAGE_TEXT = {
     "Region",
     "No storage profiles configured.",
     "Test",
-    "Edit"
+    "Edit",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the"
   ],
   "admin/users": [
     "Loading...",
@@ -1118,7 +1371,15 @@ export const PAGE_TEXT = {
     "Last Login",
     "Actions",
     "No users.",
-    "For password email"
+    "For password email",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Cancel"
   ],
   "admin/cluster": [
     "Port",
@@ -1135,6 +1396,7 @@ export const PAGE_TEXT = {
     "No clusters configured. Click New Cluster to get started.",
     "Edit",
     "node-1",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
     "Missing permissions:",
     "Re-run the setup script, or grant these to the service account.",
     "Available with reduced detail:",
@@ -1158,7 +1420,8 @@ export const PAGE_TEXT = {
     "https://10.0.0.5:6443",
     "-----BEGIN CERTIFICATE-----",
     "production",
-    "chops"
+    "chops",
+    "No options"
   ],
   "admin/app-backup": [
     "Loading...",
@@ -1189,7 +1452,9 @@ export const PAGE_TEXT = {
     "1. Download the backup file from S3",
     "2. Stop the server",
     "3. Replace the database",
-    "4. Restart the server"
+    "4. Restart the server",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the"
   ],
   "admin/api-management": [
     "Loading...",
@@ -1209,7 +1474,9 @@ export const PAGE_TEXT = {
     "No, Cancel",
     "Yes, Delete",
     "Enter the Name",
-    "Fetch models to choose one"
+    "Fetch models to choose one",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the"
   ],
   "admin/channels": [
     "Loading...",
@@ -1217,7 +1484,10 @@ export const PAGE_TEXT = {
     "Name",
     "Type",
     "No channels yet.",
-    "Test"
+    "Test",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Cancel"
   ],
   "/qurioz": [
     "Database Schema Generator",
@@ -1225,6 +1495,8 @@ export const PAGE_TEXT = {
     "Database Schema Generated",
     "Refresh Selected Schema",
     "Delete Schema's",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
     "Press Enter to send, Shift+Enter for new line.",
     "Search for query...",
     "Chat input",
@@ -1236,6 +1508,12 @@ export const PAGE_TEXT = {
     "Error occurs while executing the query",
     "Retry",
     "Chart View",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
     "Clickhouse Query",
     "Edit",
     "Copy",
@@ -1252,7 +1530,11 @@ export const PAGE_TEXT = {
     "Min",
     "Max",
     "Preview",
-    "Map columns to see preview."
+    "Map columns to see preview.",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG"
   ],
   "custom/builder": [
     "Chart building is only available for administrators.",
@@ -1274,8 +1556,22 @@ export const PAGE_TEXT = {
     "Map columns to see preview.",
     "Create a dashboard first in the Dashboards section.",
     "SELECT ...",
+    "No options",
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
     "(none)",
     "Value:",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Actions",
+    "Something went wrong",
+    "Try Again",
     "Max rows",
     "Fewer rows",
     "Maximum rows to return",
@@ -1288,6 +1584,17 @@ export const PAGE_TEXT = {
     "Dashboard",
     "Actions",
     "No charts.",
-    "Value:"
+    "webfont icons: it keeps // the original \"ti ti-NAME\" classes on the",
+    "Value:",
+    "Zoom in",
+    "Zoom out",
+    "Reset zoom",
+    "Save PNG",
+    "value",
+    "key",
+    "(empty array)",
+    "index/value list. return",
+    "(empty object)",
+    "Cancel"
   ]
 };

--- a/tests/frontend/chartTypes.test.js
+++ b/tests/frontend/chartTypes.test.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Quantrail™ Data Private Limited
 // chartTypes.test.js - the chart type registry, column validation and axis defaults
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   CHART_TYPES,
   buildChartOption,
@@ -68,6 +68,26 @@ describe("validateColumnType", () => {
   it("returns null for string expectation with string sample", () => {
     expect(validateColumnType([{ v: "abc" }], "v", "string")).toBeNull();
   });
+  it("returns null when first five samples are null/undefined", () => {
+    expect(
+      validateColumnType(
+        [{ v: null }, { v: undefined }, { v: null }, { v: undefined }, { v: null }],
+        "v",
+        "numeric",
+      ),
+    ).toBeNull();
+  });
+  it("validates only first five rows", () => {
+    const data = [
+      { v: 1 },
+      { v: 2 },
+      { v: 3 },
+      { v: 4 },
+      { v: 5 },
+      { v: "bad-after-sample" },
+    ];
+    expect(validateColumnType(data, "v", "numeric")).toBeNull();
+  });
 });
 
 describe("getAxisDefaults", () => {
@@ -96,6 +116,12 @@ describe("getAxisDefaults", () => {
     expect(getAxisDefaults("sunburst", "simple_sunburst")).toEqual({
       xLabel: "",
       yLabel: "",
+    });
+  });
+  it("returns X/Y for heatmap", () => {
+    expect(getAxisDefaults("heatmap", "matrix")).toEqual({
+      xLabel: "X",
+      yLabel: "Y",
     });
   });
 });
@@ -154,6 +180,33 @@ describe("buildChartOption - bar", () => {
     expect(Array.isArray(o.dataZoom)).toBe(true);
     expect(o.dataZoom.some((z) => z.type === "inside")).toBe(true);
   });
+  it("grouped bar creates one series per group", () => {
+    const o = buildChartOption(
+      "bar",
+      "grouped_bar",
+      [
+        { c: "A", s: "S1", v: 10 },
+        { c: "A", s: "S2", v: 20 },
+        { c: "B", s: "S1", v: 30 },
+      ],
+      { category: "c", series: "s", value: "v" },
+    );
+    expect(o.series.length).toBe(2);
+    expect(o.series[0].stack).toBeUndefined();
+  });
+  it("stacked bar enables stack and inside labels", () => {
+    const o = buildChartOption(
+      "bar",
+      "stacked_bar",
+      [
+        { c: "A", st: "X", v: 10 },
+        { c: "A", st: "Y", v: 20 },
+      ],
+      { category: "c", stack: "st", value: "v" },
+    );
+    expect(o.series.every((s) => s.stack === "total")).toBe(true);
+    expect(o.series.every((s) => s.label.position === "inside")).toBe(true);
+  });
 });
 
 describe("buildChartOption - line", () => {
@@ -189,6 +242,31 @@ describe("buildChartOption - line", () => {
     );
     expect(o.series.length).toBe(2);
     expect(o.legend.show).toBe(true);
+  });
+  it("stacked area sets stack and areaStyle", () => {
+    const o = buildChartOption(
+      "line",
+      "stacked_area",
+      [
+        { t: "1", s: "A", v: 5 },
+        { t: "1", s: "B", v: 7 },
+      ],
+      { time: "t", series: "s", value: "v" },
+    );
+    expect(o.series.every((s) => s.stack === "total")).toBe(true);
+    expect(o.series.every((s) => s.areaStyle)).toBe(true);
+  });
+  it("time axis label formatter returns compact labels", () => {
+    const o = buildChartOption(
+      "line",
+      "simple_line",
+      [{ t: "2026-01-01 10:00:00", v: 1 }, { t: "2026-01-01 11:00:00", v: 2 }],
+      { time: "t", value: "v" },
+    );
+    expect(typeof o.xAxis.axisLabel.formatter).toBe("function");
+    const sample = o.xAxis.axisLabel.formatter("2026-01-01 10:00:00");
+    expect(typeof sample).toBe("string");
+    expect(sample.length).toBeGreaterThan(0);
   });
 });
 
@@ -244,6 +322,27 @@ describe("buildChartOption - scatter", () => {
     );
     expect(o.series.length).toBe(2);
     expect(o.legend.show).toBe(true);
+  });
+
+  it("bubble symbolSize has minimum floor", () => {
+    const o = buildChartOption(
+      "scatter",
+      "bubble",
+      [{ x1: 1, y1: 2, size1: 0, cat: "A" }],
+      { x: "x1", y: "y1", size: "size1", category: "cat" },
+    );
+    expect(o.series[0].symbolSize([1, 2, 0])).toBeGreaterThanOrEqual(6);
+  });
+
+  it("basic scatter supports mapping.size symbol function", () => {
+    const o = buildChartOption(
+      "scatter",
+      "basic_scatter",
+      [{ x1: 1, y1: 2, z1: 9 }],
+      { x: "x1", y: "y1", size: "z1" },
+    );
+    expect(o.series[0].data[0]).toEqual([1, 2, 9]);
+    expect(o.series[0].symbolSize([1, 2, 9])).toBeGreaterThan(5);
   });
 });
 
@@ -315,6 +414,21 @@ describe("buildChartOption - special", () => {
     expect(o.series.length).toBeGreaterThanOrEqual(1);
     expect(o.series[0].type).toBe("boxplot");
   });
+  it("boxplot simple emits outlier scatter when present", () => {
+    const o = buildChartOption(
+      "boxplot",
+      "simple_box",
+      [
+        { c: "A", v: 10 },
+        { c: "A", v: 11 },
+        { c: "A", v: 12 },
+        { c: "A", v: 200 },
+      ],
+      { category: "c", value: "v" },
+    );
+    expect(o.series.length).toBeGreaterThanOrEqual(1);
+    expect(o.series[0].type).toBe("boxplot");
+  });
   it("sunburst simple", () => {
     const o = buildChartOption(
       "sunburst",
@@ -370,6 +484,17 @@ describe("buildChartOption - special", () => {
     );
     expect(o.series[0].type).toBe("treemap");
   });
+  it("treemap tooltip formatter returns html", () => {
+    const o = buildChartOption(
+      "treemap",
+      "hierarchical",
+      [{ name: "rootA", parent: "", value: 100 }],
+      { name: "name", parent: "parent", value: "value" },
+    );
+    const html = o.tooltip.formatter({ name: "rootA", value: 100 });
+    expect(html).toContain("rootA");
+    expect(html).toContain("100");
+  });
   it("heatmap includes visualMap", () => {
     const o = buildChartOption(
       "heatmap",
@@ -392,6 +517,55 @@ describe("buildChartOption - special", () => {
     );
     expect(o.series[0].type).toBe("candlestick");
     expect(o.series[0].data[0]).toEqual([10, 12, 8, 15]);
+  });
+  it("radar builds indicator and entity series", () => {
+    const o = buildChartOption(
+      "radar",
+      "multi_metric",
+      [
+        { m: "speed", e: "A", v: 10 },
+        { m: "speed", e: "B", v: 20 },
+        { m: "quality", e: "A", v: 30 },
+      ],
+      { metric: "m", entity: "e", value: "v" },
+    );
+    expect(o.radar.indicator.length).toBe(2);
+    expect(o.series[0].data.length).toBe(2);
+  });
+  it("kpi array payload returns array error shape", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const o = buildChartOption(
+      "kpi",
+      "single",
+      [{ l: "QPS", v: "1" }, { l: "QPS2", v: "2" }],
+      { label: "l", value: "v" },
+    );
+    expect(o._kpi).toBe(true);
+    expect(o.isArray).toBe(true);
+    expect(o.message).toContain("does not support arrays");
+    spy.mockRestore();
+  });
+  it("kpi fallback label/value works", () => {
+    const o = buildChartOption("kpi", "single", [{}], { label: "l", value: "v" }, "Fallback");
+    expect(o.label).toBe("Fallback");
+    expect(o.value).toBe("-");
+  });
+  it("returns null for unknown chart type", () => {
+    const o = buildChartOption("unknown", "x", [{ a: 1 }], { a: "a" });
+    expect(o).toBeNull();
+  });
+  it("returns _error object when mapping access throws", () => {
+    const badMapping = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("boom");
+        },
+      },
+    );
+    const o = buildChartOption("bar", "simple_bar", [{ a: 1 }], badMapping);
+    expect(o._error).toBe(true);
+    expect(o.message).toContain("boom");
   });
   it("null data", () => {
     expect(buildChartOption("bar", "simple_bar", null, {})).toBeNull();
@@ -662,5 +836,20 @@ describe('yAxisNameGap', () => {
     expect(() => yAxisNameGap({})).not.toThrow();
     expect(() => yAxisNameGap(null)).not.toThrow();
     expect(() => yAxisNameGap({ yAxis: { name: 'V' }, series: [{ data: [null, undefined, 'x'] }] })).not.toThrow();
+  });
+
+  it('supports yAxis as array and custom min/max/fontSize', () => {
+    const gap = yAxisNameGap(
+      { yAxis: [{ type: "value", name: "Y" }], series: [{ data: [5000] }] },
+      { fontSize: 10, min: 30, max: 60 },
+    );
+    expect(gap).toBeGreaterThanOrEqual(30);
+    expect(gap).toBeLessThanOrEqual(60);
+  });
+
+  it('handles negative values by absolute magnitude', () => {
+    const neg = yAxisNameGap(withData([-1200000]));
+    const pos = yAxisNameGap(withData([1200000]));
+    expect(neg).toBe(pos);
   });
 });


### PR DESCRIPTION
## Description
### Fixed the defects reported in dashboards and charts:
- Legend checkbox - Replaced hardcoded lists with registry's needsLegend(); restored legends for stacked_area, multi_box, multi_metric.
- Funnel & radar - Set hasLegend: true for both types to match intended behavior.
- Boxplot - Removed redundant special case since registry already has hasXLabel: true.
- Horizontal bar - Corrected axis label mapping so X/Y fields match actual chart axes.
- Duplicate config - Removed stale legend list from AllCharts.jsx to keep gallery and builder consistent.
- Fixed failed test cases and increased test coverage for chartTypes.js component.

## Linked Work Item
Closes [https://github.com/Quantrail-Data/CH-Ops-Pro/issues/104]

## Checklist (reminder)
- [x] Unit tests added/updated
- [ ] Documentation updated
- [x] Linked work item above
- [ ] Peer reviewed
- [x] Manually self-tested
