### PR TITLE
Added ability to connect ClickHouse via https -  internal certificate authority

### DIFF
--- a/src/backend/controllers/trustedCa.js
+++ b/src/backend/controllers/trustedCa.js
@@ -1,0 +1,117 @@
+// trustedCa.js - REST API for the trusted certificate authorities.
+// Copyright (C) 2026 Quantrail™ Data Private Limited
+
+import tls from 'node:tls';
+import {
+  listTrustedCas,
+  addTrustedCa,
+  deleteTrustedCa,
+  getCaBundle,
+} from '../services/trustedCa.js';
+import { getAllClusters } from '../services/clusterUtils.js';
+import { log } from '../services/logger.js';
+
+// Days until a certificate expires, so the list can flag one running out.
+function daysUntil(dateString) {
+  if (!dateString) return null;
+  const ms = new Date(dateString).getTime() - Date.now();
+  return Math.floor(ms / 86400000);
+}
+
+export function getTrustedCas(req, res) {
+  const rows = listTrustedCas().map(r => ({
+    id: r.id,
+    name: r.name,
+    subject: r.subject,
+    issuer: r.issuer,
+    fingerprint: r.fingerprint,
+    notBefore: r.notBefore,
+    notAfter: r.notAfter,
+    daysUntilExpiry: daysUntil(r.notAfter),
+    // The certificate itself is not secret
+  }));
+  res.json(rows);
+}
+
+export function postTrustedCa(req, res) {
+  const { name, pem } = req.body || {};
+  if (!String(name || '').trim())
+    return res.status(400).json({ error: 'A name is required.' });
+  if (!String(pem || '').trim())
+    return res.status(400).json({ error: 'Paste the certificate.' });
+
+  try {
+    addTrustedCa(name, pem);
+    log.info(`Trusted certificate authority added: ${name}`);
+    return getTrustedCas(req, res);
+  } catch (err) {
+    // parsePem throws messages written for the person pasting, so pass it on.
+    return res.status(400).json({ error: err.message });
+  }
+}
+
+export function removeTrustedCa(req, res) {
+  const id = parseInt(req.params.id, 10);
+  if (!Number.isInteger(id)) return res.status(400).json({ error: 'Bad id.' });
+
+  deleteTrustedCa(id);
+  log.info(`Trusted certificate authority removed: id ${id}`);
+  return getTrustedCas(req, res);
+}
+
+// Which clusters present a certificate signed by this authority.
+
+export async function getCaUsage(req, res) {
+  const id = parseInt(req.params.id, 10);
+  const all = listTrustedCas();
+  const target = all.find(c => c.id === id);
+  if (!target) return res.status(404).json({ error: 'Not found.' });
+
+  const bundle = getCaBundle();
+  const results = [];
+
+  for (const cluster of getAllClusters()) {
+    const node = cluster.nodes?.[0];
+    if (!node || !node.secure) {
+      results.push({ cluster: cluster.name, status: 'not-tls' });
+      continue;
+    }
+
+    try {
+      const issuer = await peerIssuer(node.host, node.port, bundle);
+      results.push({
+        cluster: cluster.name,
+        // The issuer named on the server's certificate is the authority that signed it.
+        status: issuer && target.subject?.includes(issuer) ? 'uses-this' : 'other',
+        issuer,
+      });
+    } catch (err) {
+      // A cluster that is down tells us nothing either way
+      results.push({ cluster: cluster.name, status: 'unreachable', error: err.message });
+    }
+  }
+
+  res.json({ id, name: target.name, results });
+}
+
+// Opens a TLS connection and reads the issuer from the certificate presented.
+function peerIssuer(host, port, ca) {
+  return new Promise((resolve, reject) => {
+    const socket = tls.connect(
+      {
+        host,
+        port: port || 8443,
+        servername: host,
+        ...(ca ? { ca } : {}),
+        timeout: 5000,
+      },
+      () => {
+        const cert = socket.getPeerCertificate();
+        socket.end();
+        resolve(cert?.issuer?.CN || null);
+      },
+    );
+    socket.on('error', err => reject(err));
+    socket.on('timeout', () => { socket.destroy(); reject(new Error('Timed out.')); });
+  });
+}

--- a/src/backend/db/index.js
+++ b/src/backend/db/index.js
@@ -26,8 +26,8 @@ try {
   process.exit(1);
 }
 
-// Add columns from newer versions. Safe to run every time - SQLite throws
-// (and we catch) if the column already exists.
+// Add columns from newer versions. Safe to run every time - SQLite throws  if the column already exists.
+
 try { sqlite.exec("ALTER TABLE alert_rule ADD COLUMN nodes TEXT"); } catch {}
 try { sqlite.exec("ALTER TABLE alert_rule ADD COLUMN cluster_id TEXT"); } catch {}
 
@@ -35,8 +35,7 @@ export const db = drizzle(sqlite, { schema });
 
 // Re-export schema tables for convenience.
 // Explicit individual exports are used (instead of `export { } from './schema.js'`)
-// because Bun's static ESM checker cannot always resolve the re-export chain when
-// the same module is also imported as a namespace above.
+
 export const appSettings = schema.appSettings;
 export const alertRules = schema.alertRules;
 export const alertChannels = schema.alertChannels;
@@ -49,6 +48,7 @@ export const appUsers = schema.appUsers;
 export const clusters = schema.clusters;
 export const clusterNodes = schema.clusterNodes;
 export const k8sConnections = schema.k8sConnections;
+export const trustedCas = schema.trustedCas;
 
 // The raw handle, for the cluster storage migration.
 export const rawSqlite = sqlite;

--- a/src/backend/db/migrate.js
+++ b/src/backend/db/migrate.js
@@ -146,6 +146,18 @@ sqlite.exec(`
     expires_at TEXT,
     UNIQUE (jti, context)
   );
+  CREATE TABLE IF NOT EXISTS trusted_ca (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    pem TEXT NOT NULL,
+    subject TEXT,
+    issuer TEXT,
+    fingerprint TEXT,
+    not_before TEXT,
+    not_after TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+  );
 `);
 
 // Add columns that may be missing from earlier versions.

--- a/src/backend/db/schema.js
+++ b/src/backend/db/schema.js
@@ -246,3 +246,20 @@ export const k8sConnections = sqliteTable("k8s_connection", {
   createdAt: text("created_at").default(sql`(datetime('now'))`),
   updatedAt: text("updated_at").default(sql`(datetime('now'))`),
 });
+
+export const trustedCas = sqliteTable("trusted_ca", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  pem: text("pem").notNull(),
+
+  // Parsed once when saved, so the list can be shown without re-parsing every
+  // certificate on every page load.
+  subject: text("subject"),
+  issuer: text("issuer"),
+  fingerprint: text("fingerprint"),
+  notBefore: text("not_before"),
+  notAfter: text("not_after"),
+
+  createdAt: text("created_at").default(sql`(datetime('now'))`),
+  updatedAt: text("updated_at").default(sql`(datetime('now'))`),
+});

--- a/src/backend/routes/trustedCa.js
+++ b/src/backend/routes/trustedCa.js
@@ -1,0 +1,21 @@
+// trustedCa.js - routes for the trusted certificate authorities.
+// Copyright (C) 2026 Quantrail™ Data Private Limited
+
+import { Router } from 'express';
+import { requireAdmin } from '../controllers/users.js';
+import {
+  getTrustedCas,
+  postTrustedCa,
+  removeTrustedCa,
+  getCaUsage,
+} from '../controllers/trustedCa.js';
+
+const router = Router();
+
+// Admin rather than superadmin
+router.get('/', requireAdmin, getTrustedCas);
+router.post('/', requireAdmin, postTrustedCa);
+router.delete('/:id', requireAdmin, removeTrustedCa);
+router.get('/:id/usage', requireAdmin, getCaUsage);
+
+export default router;

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -40,6 +40,7 @@ import authRoute from './routes/auth.js';
 import queryRoute from './routes/query.js';
 import configRoute from './routes/config.js';
 import settingsRoute from './routes/settings.js';
+import trustedCaRoute from './routes/trustedCa.js';
 import systemSmtpRoute from './routes/systemSmtp.js';
 import alertsRoute from './routes/alerts.js';
 import dashboardsRoute from './routes/dashboards.js';
@@ -73,9 +74,7 @@ onRevoke((jti) => { try { cancelJobsForJti(jti); } catch {} });
 pruneExpired();
 setInterval(pruneExpired, 10 * 60 * 1000).unref?.();
 
-// version.generated.js is written by scripts/generate-version.mjs from
-// version.json, the single source of truth. loadEnv() used to supply this from
-// CLICKHOUSEVERSION / MAJOR / MINOR / 
+// version.generated.js is written by scripts/generate-version.mjs from version.json
 
 let appVersion = { version: '0.0.0' };
 try {
@@ -136,6 +135,7 @@ app.use('/api/query', authMiddleware, rateLimiter(10000, 60), queryRoute);
 app.use('/api/editor', authMiddleware,rateLimiter(10000, 60), editorRoute);
 app.use('/api/config', authMiddleware,rateLimiter(10000, 60), configRoute);
 app.use('/api/settings', authMiddleware,rateLimiter(10000, 60), settingsRoute);
+app.use('/api/trusted-cas', authMiddleware, rateLimiter(60, 60), trustedCaRoute);
 app.use('/api/system-smtp', authMiddleware, rateLimiter(30, 60), systemSmtpRoute);
 app.use('/api/alerts', authMiddleware,rateLimiter(10000, 60), alertsRoute);
 app.use('/api/dashboards', authMiddleware,rateLimiter(10000, 60), dashboardsRoute);

--- a/src/backend/services/clickhouse.js
+++ b/src/backend/services/clickhouse.js
@@ -3,6 +3,7 @@
 // Copyright (C) 2026 Quantrail™ Data Private Limited
 
 import { isDataQuery as sqlIsDataQuery, leadingKeyword } from '../../shared/sqlClassify.js';
+import { getCaBundle } from './trustedCa.js';
 
 // The ceiling on how much a single query may return to the application.
 const DEFAULT_MAX_RESULT_BYTES = 128 * 1024 * 1024;
@@ -70,11 +71,16 @@ export async function executeQuery({
 
   let res;
   try {
+    // Certificates the operator has told us to trust. Supplying them adds to the system list rather than replacing it,
+    // so a cluster with a publicly signed certificate is unaffected. 
+    const caBundle = getCaBundle();
+
     res = await fetch(url, {
       method: 'POST',
       headers: { 'X-ClickHouse-User': user, 'X-ClickHouse-Key': password, 'X-ClickHouse-Summary': '1' },
       body: fullSql,
       signal: abortSignal,
+      ...(caBundle ? { tls: { ca: caBundle } } : {}),
     });
   } catch (err) {
     if (timer) clearTimeout(timer);
@@ -149,10 +155,12 @@ export async function executeQueryWithBody({
   url.searchParams.set('max_execution_time', String(maxExecutionTime));
   url.searchParams.set('max_memory_usage', String(maxMemoryUsage));
 
+  const caBundle2 = getCaBundle();
   const res = await fetch(url.toString(), {
     method: 'POST',
     headers: { 'X-ClickHouse-User': user, 'X-ClickHouse-Key': password, 'X-ClickHouse-Summary': '1' },
     body,
+    ...(caBundle2 ? { tls: { ca: caBundle2 } } : {}),
   });
 
   const text = await res.text();

--- a/src/backend/services/exportStream.js
+++ b/src/backend/services/exportStream.js
@@ -3,6 +3,7 @@
 // author -> Sanjeev Kumar G
 
 import { normalizeForExport } from "../../shared/sqlExport.js";
+import { getCaBundle } from './trustedCa.js';
 
 
 const SAFE_SETTING_NAME = /^[a-z0-9_]+$/i;
@@ -35,11 +36,13 @@ export async function startExportStream({
   const url = buildUrl({ host, port, secure, settings, queryId });
   const body = `${normalizeForExport(sql)}\nFORMAT ${format}`;
 
+  const caBundle = getCaBundle();
   const res = await fetch(url, {
     method: "POST",
     headers: authHeaders(user, password),
     body,
     signal,
+    ...(caBundle ? { tls: { ca: caBundle } } : {}),
   });
 
   if (!res.ok) {
@@ -56,10 +59,13 @@ export async function measureBytes({
   const url = buildUrl({ host, port, secure, settings });
   url.searchParams.set("max_execution_time", "30");
 
+  const caBundle = getCaBundle();
   const res = await fetch(url, {
     method: "POST",
     headers: authHeaders(user, password),
-    body: `${sql}\nFORMAT ${format}`,
+    body,
+    signal,
+    ...(caBundle ? { tls: { ca: caBundle } } : {}),
   });
 
   if (!res.ok) {
@@ -87,10 +93,14 @@ export async function killExportQuery({ host, port, secure, user, password, quer
   const proto = secure ? "https" : "http";
   const safeId = String(queryId).replace(/'/g, "''");
   try {
+    // Inside the try, not above it. This function is written never to throw,
+    // and reading the bundle touches the database.
+    const caBundle = getCaBundle();
     await fetch(`${proto}://${host}:${port || 8123}/`, {
       method: "POST",
       headers: authHeaders(user, password),
       body: `KILL QUERY WHERE query_id = '${safeId}' ASYNC`,
+      ...(caBundle ? { tls: { ca: caBundle } } : {}),
     });
   } catch {
     

--- a/src/backend/services/exportStream.js
+++ b/src/backend/services/exportStream.js
@@ -63,8 +63,7 @@ export async function measureBytes({
   const res = await fetch(url, {
     method: "POST",
     headers: authHeaders(user, password),
-    body,
-    signal,
+    body: `${sql}\nFORMAT ${format}`,
     ...(caBundle ? { tls: { ca: caBundle } } : {}),
   });
 

--- a/src/backend/services/trustedCa.js
+++ b/src/backend/services/trustedCa.js
@@ -5,6 +5,7 @@
 import crypto from 'node:crypto';
 import { eq } from 'drizzle-orm';
 import { db, trustedCas } from '../db/index.js';
+import { trustedCas } from '../db/schema.js';
 
 // Built once and reused. Rebuilt whenever a certificate is added or removed.
 

--- a/src/backend/services/trustedCa.js
+++ b/src/backend/services/trustedCa.js
@@ -1,0 +1,84 @@
+// trustedCa.js - certificate authorities CHOps trusts for outbound TLS.
+// Contributors - Praveen, Kathirmoorthy, Kathirdhasan
+// Copyright (C) 2026 Quantrail™ Data Private Limited
+
+import crypto from 'node:crypto';
+import { eq } from 'drizzle-orm';
+import { db, trustedCas } from '../db/index.js';
+
+// Built once and reused. Rebuilt whenever a certificate is added or removed.
+
+let cachedBundle = null;
+
+// Reads a certificate and pulls out what the list needs to show.
+export function parsePem(pem) {
+  let cert;
+  try {
+    cert = new crypto.X509Certificate(pem);
+  } catch {
+    throw new Error('That does not look like a certificate. Paste the whole PEM block, including the BEGIN and END lines.');
+  }
+
+  // A server certificate is not an authority and cannot sign anything.
+
+  if (!cert.ca) {
+    throw new Error('That is a certificate, but not a certificate authority. You need the CA certificate that signed your server, not the server certificate itself.');
+  }
+
+  const notAfter = new Date(cert.validTo);
+  if (notAfter.getTime() < Date.now()) {
+    throw new Error(`That certificate authority expired on ${cert.validTo}. An expired one cannot validate anything.`);
+  }
+
+  return {
+    subject: cert.subject,
+    issuer: cert.issuer,
+    fingerprint: cert.fingerprint256,
+    notBefore: cert.validFrom,
+    notAfter: cert.validTo,
+  };
+}
+
+export function listTrustedCas() {
+  return db.select().from(trustedCas).orderBy(trustedCas.name).all();
+}
+
+export function addTrustedCa(name, pem) {
+  const parsed = parsePem(pem);
+
+  // The fingerprint identifies a certificate uniquely, so this catches the same one being pasted twice under two names.
+  const existing = db.select().from(trustedCas)
+    .where(eq(trustedCas.fingerprint, parsed.fingerprint)).get();
+  if (existing) {
+    throw new Error(`That certificate authority is already stored, under the name "${existing.name}".`);
+  }
+
+  db.insert(trustedCas).values({ name: name.trim(), pem: pem.trim(), ...parsed }).run();
+  cachedBundle = null;
+}
+
+export function deleteTrustedCa(id) {
+  db.delete(trustedCas).where(eq(trustedCas.id, id)).run();
+  cachedBundle = null;
+}
+
+// Every stored certificate, joined into one block.
+
+export function getCaBundle() {
+  if (cachedBundle !== null) return cachedBundle || null;
+
+  const rows = db.select().from(trustedCas).all();
+  if (!rows.length) {
+    cachedBundle = '';
+    return null;
+  }
+
+  // Supplying these adds to the system list rather than replacing it
+  cachedBundle = rows.map(r => r.pem.trim()).join('\n');
+  return cachedBundle;
+}
+
+// For tests and for anything that changes the table without going through the functions above.
+export function invalidateCaBundle() {
+  cachedBundle = null;
+}

--- a/src/backend/services/trustedCa.js
+++ b/src/backend/services/trustedCa.js
@@ -4,7 +4,7 @@
 
 import crypto from 'node:crypto';
 import { eq } from 'drizzle-orm';
-import { db, trustedCas } from '../db/index.js';
+import { db } from '../db/index.js';
 import { trustedCas } from '../db/schema.js';
 
 // Built once and reused. Rebuilt whenever a certificate is added or removed.

--- a/src/backend/services/trustedCa.js
+++ b/src/backend/services/trustedCa.js
@@ -68,13 +68,20 @@ export function deleteTrustedCa(id) {
 export function getCaBundle() {
   if (cachedBundle !== null) return cachedBundle || null;
 
-  const rows = db.select().from(trustedCas).all();
+  let rows;
+  try {
+    rows = db.select().from(trustedCas).all();
+  } catch {
+    // No certificates is the correct answer when the table cannot be read
+    cachedBundle = '';
+    return null;
+  }
+
   if (!rows.length) {
     cachedBundle = '';
     return null;
   }
 
-  // Supplying these adds to the system list rather than replacing it
   cachedBundle = rows.map(r => r.pem.trim()).join('\n');
   return cachedBundle;
 }

--- a/src/frontend/components/admin/TrustedCas.jsx
+++ b/src/frontend/components/admin/TrustedCas.jsx
@@ -1,0 +1,207 @@
+// TrustedCas.jsx - manage the certificate authorities CHOps trusts.
+// Copyright (C) 2026 Quantrail™ Data Private Limited
+
+import React, { useState, useEffect } from 'react';
+import Icon from "../common/Icon.jsx";
+import { apiFetch } from "../../utils/api.js";
+import { useToast } from "../layout/Toast.jsx";
+import ConfirmModal from "../layout/ConfirmModal.jsx";
+
+export default function TrustedCas() {
+  const toast = useToast();
+  const [cas, setCas] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [name, setName] = useState('');
+  const [pem, setPem] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [deleting, setDeleting] = useState(null);
+  const [usage, setUsage] = useState(null);
+
+  useEffect(() => { load(); }, []);
+
+  async function load() {
+    try {
+      setCas(await apiFetch('/api/trusted-cas'));
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function add() {
+    setBusy(true);
+    try {
+      setCas(await apiFetch('/api/trusted-cas', {
+        method: 'POST',
+        body: JSON.stringify({ name: name.trim(), pem }),
+      }));
+      setAdding(false);
+      setName('');
+      setPem('');
+      toast.success('Certificate authority added.');
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(id) {
+    try {
+      setCas(await apiFetch(`/api/trusted-cas/${id}`, { method: 'DELETE' }));
+      setDeleting(null);
+      toast.success('Removed.');
+    } catch (err) {
+      toast.error(err.message);
+    }
+  }
+
+  async function checkUsage(ca) {
+    setUsage({ name: ca.name, loading: true });
+    try {
+      setUsage({ ...(await apiFetch(`/api/trusted-cas/${ca.id}/usage`)), loading: false });
+    } catch (err) {
+      setUsage(null);
+      toast.error(err.message);
+    }
+  }
+
+  if (loading) return <div className="page-content"><div className="loading-spinner" /></div>;
+
+  return (
+    <div className="page-content">
+      <div className="section-header">
+        <h2 className="section-title">
+          <Icon className="ti ti-certificate" /> Trusted certificate authorities
+        </h2>
+        <button className="btn btn-primary btn-sm" onClick={() => setAdding(true)}>
+          <Icon className="ti ti-plus" /> Add
+        </button>
+      </div>
+
+      <p style={{ fontSize: 13, color: 'var(--text-muted)', marginBottom: 20, maxWidth: 700 }}>
+        Add your organisation's certificate authority here if ClickHouse uses
+        HTTPS with a certificate you issued yourself. Without it, CHOps cannot
+        verify the connection and reports "unable to verify the first
+        certificate". These are added to the authorities your system already
+        trusts, so public certificates keep working.
+      </p>
+
+      {!cas.length && (
+        <div className="empty-state" style={{ padding: 40 }}>
+          No certificate authorities added. CHOps uses the system list only.
+        </div>
+      )}
+
+      {cas.map(ca => (
+        <div key={ca.id} className="card" style={{ padding: 16, marginBottom: 12 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <div style={{ fontWeight: 600, marginBottom: 4 }}>{ca.name}</div>
+              <div style={{ fontSize: 12, color: 'var(--text-muted)' }}>
+                <div>Subject: {ca.subject}</div>
+                <div>Fingerprint: {ca.fingerprint?.slice(0, 32)}...</div>
+                <div>
+                  Expires: {ca.notAfter}{' '}
+                  {ca.daysUntilExpiry != null && (
+                    <strong style={{ color: ca.daysUntilExpiry < 30 ? 'var(--danger)' : 'inherit' }}>
+                      ({ca.daysUntilExpiry} days)
+                    </strong>
+                  )}
+                </div>
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button className="btn btn-secondary btn-sm" onClick={() => checkUsage(ca)}>
+                Which clusters use this
+              </button>
+              <button className="btn btn-danger btn-sm" onClick={() => setDeleting(ca)}>
+                <Icon className="ti ti-trash" />
+              </button>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      {adding && (
+        <div className="modal-overlay">
+          <div className="modal-box" style={{ maxWidth: 640, width: '94%' }}>
+            <div style={{ fontWeight: 600, marginBottom: 14 }}>Add a certificate authority</div>
+
+            <div className="form-group">
+              <label className="form-label">Name</label>
+              <input className="form-input" style={{ width: '100%' }}
+                value={name} onChange={e => setName(e.target.value)}
+                placeholder="Internal CA" />
+            </div>
+
+            <div className="form-group">
+              <label className="form-label">Certificate</label>
+              <textarea className="form-input" rows={10}
+                style={{ width: '100%', fontFamily: 'monospace', fontSize: 12 }}
+                value={pem} onChange={e => setPem(e.target.value)}
+                placeholder={'-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----'} />
+              <div style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 4 }}>
+                Paste the whole block, including the BEGIN and END lines. This
+                must be the certificate authority, not the server certificate.
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button className="btn btn-secondary btn-sm" disabled={busy}
+                onClick={() => setAdding(false)}>Cancel</button>
+              <button className="btn btn-primary btn-sm"
+                disabled={busy || !name.trim() || !pem.trim()}
+                onClick={add}>{busy ? 'Checking...' : 'Add'}</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {usage && (
+        <div className="modal-overlay" onClick={() => setUsage(null)}>
+          <div className="modal-box" style={{ maxWidth: 520, width: '94%' }} onClick={e => e.stopPropagation()}>
+            <div style={{ fontWeight: 600, marginBottom: 12 }}>
+              Clusters using {usage.name}
+            </div>
+            {usage.loading ? (
+              <div className="loading-spinner" />
+            ) : (
+              <>
+                {usage.results?.map(r => (
+                  <div key={r.cluster} style={{ fontSize: 13, marginBottom: 6 }}>
+                    <strong>{r.cluster}</strong>{': '}
+                    {r.status === 'uses-this' && 'uses this authority'}
+                    {r.status === 'other' && `uses a different one (${r.issuer || 'unknown'})`}
+                    {r.status === 'not-tls' && 'not using TLS'}
+                    {r.status === 'unreachable' && 'could not be reached'}
+                  </div>
+                ))}
+                <p style={{ fontSize: 12, color: 'var(--text-muted)', marginTop: 12 }}>
+                  Only clusters that responded are listed accurately. One that is
+                  down shows as unreachable, not as unaffected.
+                </p>
+              </>
+            )}
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 12 }}>
+              <button className="btn btn-secondary btn-sm" onClick={() => setUsage(null)}>Close</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {deleting && (
+        <ConfirmModal
+          title="Remove this certificate authority?"
+          message={`"${deleting.name}" will no longer be trusted. Any cluster whose certificate it signed will stop connecting until it is added again. Use the usage check first if you are unsure.`}
+          confirmText="Remove"
+          onConfirm={() => remove(deleting.id)}
+          onCancel={() => setDeleting(null)}
+          danger
+        />
+      )}
+    </div>
+  );
+}

--- a/src/frontend/components/layout/MainLayout.jsx
+++ b/src/frontend/components/layout/MainLayout.jsx
@@ -51,6 +51,7 @@ const Playback = lazy(() => import("../monitoring/Playback.jsx"));
 const MemoryAllocator = lazy(() => import("../monitoring/MemoryAllocator.jsx"));
 const AlertRules = lazy(() => import("../alerting/AlertRules.jsx"));
 const NotificationChannels = lazy(() => import("../admin/NotificationChannels.jsx"),);
+const TrustedCas = lazy(() => import("../admin/TrustedCas.jsx"));
 const RbacViewGrants = lazy(() => import("../rbac/RbacViewGrants.jsx"));
 const RbacUsers = lazy(() => import("../rbac/RbacUsers.jsx"));
 const RbacRoles = lazy(() => import("../rbac/RbacRoles.jsx"));
@@ -116,6 +117,7 @@ const CORE_ROUTES = [
   ["admin/app-backup", AppDataBackup],
   ["admin/api-management", ApiManagement],
   ["admin/channels", NotificationChannels],
+  ["admin/trusted-cas", TrustedCas],
   ["/qurioz", QuriozChatComponent],
   
   // ["/qurioz/:session_id?", QuriozChatComponent],

--- a/src/frontend/components/layout/Sidebar.jsx
+++ b/src/frontend/components/layout/Sidebar.jsx
@@ -149,6 +149,7 @@ const CORE_NAV_ITEMS = [
       { id: "admin/cluster", label: "Cluster Management" },
       { id: "admin/profiles", label: "Storage Profiles" },
       { id: "admin/channels", label: "Notification Channels" },
+      { id: "admin/trusted-cas", label: "Trusted CAs" },
       { id: "admin/app-backup", label: "App Data Backup" },
       { id: "admin/api-management", label: "AI API Keys" },
     ],

--- a/src/frontend/utils/routeMeta.js
+++ b/src/frontend/utils/routeMeta.js
@@ -113,4 +113,5 @@ export const BREADCRUMB_MAP = {
   "admin/app-backup": ["Administration", "App Data Backup"],
   "admin/api-management": ["Administration", "API Management"],
   "admin/channels": ["Administration", "Notification Channels"],
+  "admin/trusted-cas": ["Administration", "Trusted Certificate Authorities"],
 };

--- a/src/frontend/utils/searchCatalog.js
+++ b/src/frontend/utils/searchCatalog.js
@@ -314,6 +314,13 @@ export const SEARCH_CATALOG = [
     description: "Notification channels: email, Slack, Google Chat, Teams, PagerDuty.",
     keywords: ["alert channels", "notification channels", "email", "slack", "webhook", "pagerduty", "microsoft teams", "google chat", "notify", "integrations"],
   },
+    {
+    id: "admin/trusted-cas",
+    title: "Trusted CAs",
+    section: "Admin",
+    description: "Certificate authorities CHOps trusts when connecting to ClickHouse over TLS.",
+    keywords: ["certificate", "certificate authority", "ca", "tls", "ssl", "https", "self-signed", "internal ca", "unable to verify"],
+  },
   {
     id: "admin/api-management",
     title: "AI API Keys",
@@ -324,13 +331,7 @@ export const SEARCH_CATALOG = [
 ];
 
 // Fold in already-existing constants (breadcrumb labels + scraped headers).
-// The curated `keywords` above carry intent and synonyms. On top of them we
-// merge two constant sources that already exist in the codebase, so they stay
-// in sync automatically:
-//   1. BREADCRUMB_MAP  - section, page, and sub-tab labels per route.
-//   2. PAGE_HEADERS     - constant in-page section headers scraped at build time.
-// Token search (with IDF) down-weights the generic labels this adds, so the
-// merge improves recall without drowning out the specific terms.
+
 
 function breadcrumbTerms(id) {
   const out = [];

--- a/tests/db/clusterRoundTrip.test.js
+++ b/tests/db/clusterRoundTrip.test.js
@@ -3,10 +3,6 @@
 // Copyright (C) 2026 Quantrail™ Data Private Limited
 
 
-
-// Runs as its own `bun test tests/db` invocation, not with tests/backend.
-
-
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { Database } from "bun:sqlite";
 import { drizzle } from "drizzle-orm/bun-sqlite";
@@ -62,9 +58,18 @@ const db = drizzle(sqlite, { schema });
 mock.module("../../src/backend/db/index.js", () => ({
   db,
   appSettings: schema.appSettings,
+  alertRules: schema.alertRules,
+  alertChannels: schema.alertChannels,
+  alertRuleChannels: schema.alertRuleChannels,
+  dashboards: schema.dashboards,
+  charts: schema.charts,
+  appUsers: schema.appUsers,
   clusters: schema.clusters,
   clusterNodes: schema.clusterNodes,
+  k8sConnections: schema.k8sConnections,
+  trustedCas: schema.trustedCas,
   rawSqlite: sqlite,
+  assertDatabaseReadable: () => {},
 }));
 
 

--- a/tests/db/systemSmtp.test.js
+++ b/tests/db/systemSmtp.test.js
@@ -26,9 +26,18 @@ const db = drizzle(sqlite, { schema });
 mock.module("../../src/backend/db/index.js", () => ({
   db,
   appSettings: schema.appSettings,
+  alertRules: schema.alertRules,
+  alertChannels: schema.alertChannels,
+  alertRuleChannels: schema.alertRuleChannels,
+  dashboards: schema.dashboards,
+  charts: schema.charts,
+  appUsers: schema.appUsers,
   clusters: schema.clusters,
   clusterNodes: schema.clusterNodes,
+  k8sConnections: schema.k8sConnections,
+  trustedCas: schema.trustedCas,
   rawSqlite: sqlite,
+  assertDatabaseReadable: () => {},
 }));
 
 const { readStoredSmtp, saveSystemSmtp, deleteSystemSmtp } = await import(

--- a/tests/db/trustedCa.test.js
+++ b/tests/db/trustedCa.test.js
@@ -1,0 +1,205 @@
+// trustedCa.test.js - storing certificate authorities and building the bundle
+// Copyright (C) 2026 Quantrail™ Data Private Limited
+
+// In tests/db because it needs the real trustedCa service against a real
+// database. Files in tests/backend mock db/index.js, and mock.module applies to
+// the whole test process, so sharing an invocation with them would replace the
+// database this file supplies.
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { Database } from "bun:sqlite";
+import { drizzle } from "drizzle-orm/bun-sqlite";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as schema from "../../src/backend/db/schema.js";
+
+const sqlite = new Database(":memory:");
+sqlite.exec(`
+  CREATE TABLE trusted_ca (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    pem TEXT NOT NULL,
+    subject TEXT,
+    issuer TEXT,
+    fingerprint TEXT,
+    not_before TEXT,
+    not_after TEXT,
+    created_at TEXT DEFAULT (datetime('now')),
+    updated_at TEXT DEFAULT (datetime('now'))
+  );
+`);
+
+const db = drizzle(sqlite, { schema });
+
+mock.module("../../src/backend/db/index.js", () => ({
+  db,
+  appSettings: schema.appSettings,
+  alertRules: schema.alertRules,
+  alertChannels: schema.alertChannels,
+  alertRuleChannels: schema.alertRuleChannels,
+  dashboards: schema.dashboards,
+  charts: schema.charts,
+  appUsers: schema.appUsers,
+  clusters: schema.clusters,
+  clusterNodes: schema.clusterNodes,
+  k8sConnections: schema.k8sConnections,
+  trustedCas: schema.trustedCas,
+  rawSqlite: sqlite,
+  assertDatabaseReadable: () => {},
+}));
+
+const {
+  listTrustedCas,
+  addTrustedCa,
+  deleteTrustedCa,
+  getCaBundle,
+  parsePem,
+} = await import("../../src/backend/services/trustedCa.js");
+
+// Real certificates, generated once. Using openssl rather than a fixture so
+// nothing expires and breaks this suite in a year.
+function makeCa(cn) {
+  const dir = mkdtempSync(join(tmpdir(), "ca-"));
+  execFileSync("openssl", [
+    "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", join(dir, "ca.key"), "-out", join(dir, "ca.crt"),
+    "-days", "365", "-subj", `/CN=${cn}`,
+  ], { stdio: "ignore" });
+  return readFileSync(join(dir, "ca.crt"), "utf8");
+}
+
+function makeServerCert() {
+  const dir = mkdtempSync(join(tmpdir(), "srv-"));
+  execFileSync("openssl", [
+    "req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", join(dir, "s.key"), "-out", join(dir, "s.crt"),
+    "-days", "365", "-subj", "/CN=localhost",
+    "-addext", "basicConstraints=CA:FALSE",
+  ], { stdio: "ignore" });
+  return readFileSync(join(dir, "s.crt"), "utf8");
+}
+
+const caA = makeCa("Test CA A");
+const caB = makeCa("Test CA B");
+const serverCert = makeServerCert();
+
+beforeEach(() => {
+  sqlite.exec("DELETE FROM trusted_ca");
+  // The bundle is cached in the module, and the delete above bypasses the
+  // functions that clear it.
+  deleteTrustedCa(-1);
+});
+
+describe("storing a certificate authority", () => {
+  it("saves it with its parsed fields", () => {
+    addTrustedCa("Authority A", caA);
+
+    const rows = listTrustedCas();
+    expect(rows.length).toBe(1);
+    expect(rows[0].name).toBe("Authority A");
+    expect(rows[0].subject).toContain("Test CA A");
+    expect(rows[0].fingerprint).toBeTruthy();
+    expect(rows[0].notAfter).toBeTruthy();
+  });
+
+  it("stores the certificate as plain text, not encrypted", () => {
+    // A CA certificate is public by design. Encrypting it would tie it to
+    // SESSION_SECRET for no benefit, and it would be lost on a rotation.
+    addTrustedCa("Authority A", caA);
+    const raw = sqlite.query("SELECT pem FROM trusted_ca").get();
+    expect(raw.pem).toContain("BEGIN CERTIFICATE");
+  });
+
+  it("refuses the same certificate twice", () => {
+    addTrustedCa("Authority A", caA);
+    // Named differently, same bytes. The fingerprint is what catches it.
+    expect(() => addTrustedCa("Same one again", caA)).toThrow(/already stored/);
+    expect(listTrustedCas().length).toBe(1);
+  });
+
+  it("names the existing entry when refusing a duplicate", () => {
+    addTrustedCa("Authority A", caA);
+    try {
+      addTrustedCa("Different name", caA);
+    } catch (err) {
+      // Without the name, the user has to hunt through the list to find it.
+      expect(err.message).toContain("Authority A");
+    }
+  });
+
+  it("refuses a server certificate", () => {
+    // The mistake people actually make: ca.crt and server.crt sit next to each
+    // other and only one of them works.
+    expect(() => addTrustedCa("Wrong file", serverCert)).toThrow(/not a certificate authority/);
+    expect(listTrustedCas().length).toBe(0);
+  });
+
+  it("refuses rubbish", () => {
+    expect(() => addTrustedCa("Nonsense", "hello")).toThrow();
+    expect(listTrustedCas().length).toBe(0);
+  });
+});
+
+describe("the bundle sent on every connection", () => {
+  it("is null when nothing is stored", () => {
+    // Callers must then leave the tls option out entirely rather than passing
+    // an empty value, which is untested territory in Bun.
+    expect(getCaBundle()).toBeNull();
+  });
+
+  it("contains one certificate when one is stored", () => {
+    addTrustedCa("Authority A", caA);
+    const bundle = getCaBundle();
+    expect(bundle).toContain("BEGIN CERTIFICATE");
+    expect(bundle.match(/BEGIN CERTIFICATE/g).length).toBe(1);
+  });
+
+  it("joins several certificates", () => {
+    addTrustedCa("Authority A", caA);
+    addTrustedCa("Authority B", caB);
+    const bundle = getCaBundle();
+    expect(bundle.match(/BEGIN CERTIFICATE/g).length).toBe(2);
+  });
+
+  it("changes as soon as one is added", () => {
+    // This is what makes a new authority work without restarting CHOps.
+    expect(getCaBundle()).toBeNull();
+    addTrustedCa("Authority A", caA);
+    expect(getCaBundle()).toContain("BEGIN CERTIFICATE");
+  });
+
+  it("changes as soon as one is removed", () => {
+    addTrustedCa("Authority A", caA);
+    const id = listTrustedCas()[0].id;
+
+    deleteTrustedCa(id);
+
+    expect(getCaBundle()).toBeNull();
+    expect(listTrustedCas().length).toBe(0);
+  });
+
+  it("drops only the one removed", () => {
+    addTrustedCa("Authority A", caA);
+    addTrustedCa("Authority B", caB);
+    const a = listTrustedCas().find(r => r.name === "Authority A");
+
+    deleteTrustedCa(a.id);
+
+    const bundle = getCaBundle();
+    expect(bundle.match(/BEGIN CERTIFICATE/g).length).toBe(1);
+    expect(listTrustedCas()[0].name).toBe("Authority B");
+  });
+});
+
+describe("parsePem", () => {
+  it("returns the fields the list needs", () => {
+    const p = parsePem(caA);
+    expect(p.subject).toContain("Test CA A");
+    expect(p.issuer).toContain("Test CA A");
+    expect(p.fingerprint).toMatch(/^[0-9A-F:]+$/);
+    expect(p.notBefore).toBeTruthy();
+    expect(p.notAfter).toBeTruthy();
+  });
+});

--- a/tests/net/trustedCaTls.test.js
+++ b/tests/net/trustedCaTls.test.js
@@ -1,0 +1,137 @@
+// trustedCaTls.test.js - the TLS behaviour the certificate authority feature relies on
+// Copyright (C) 2026 Quantrail™ Data Private Limited
+
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import tls from "node:tls";
+import https from "node:https";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let caPem, caPem2, server, port;
+
+beforeAll(async () => {
+  const dir = mkdtempSync(join(tmpdir(), "tls-"));
+  const p = (f) => join(dir, f);
+
+  // An authority, and a server certificate it signs.
+  execFileSync("openssl", ["req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", p("ca.key"), "-out", p("ca.crt"), "-days", "365",
+    "-subj", "/CN=Test Internal CA"], { stdio: "ignore" });
+
+  execFileSync("openssl", ["req", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", p("srv.key"), "-out", p("srv.csr"),
+    "-subj", "/CN=localhost"], { stdio: "ignore" });
+
+  writeFileSync(p("san.ext"), "subjectAltName=DNS:localhost,IP:127.0.0.1\nbasicConstraints=CA:FALSE\n");
+
+  execFileSync("openssl", ["x509", "-req", "-in", p("srv.csr"),
+    "-CA", p("ca.crt"), "-CAkey", p("ca.key"), "-CAcreateserial",
+    "-out", p("srv.crt"), "-days", "365", "-extfile", p("san.ext")], { stdio: "ignore" });
+
+  // A second, unrelated authority, to prove a bundle works.
+  execFileSync("openssl", ["req", "-x509", "-newkey", "rsa:2048", "-nodes",
+    "-keyout", p("ca2.key"), "-out", p("ca2.crt"), "-days", "365",
+    "-subj", "/CN=Other CA"], { stdio: "ignore" });
+
+  caPem = readFileSync(p("ca.crt"), "utf8");
+  caPem2 = readFileSync(p("ca2.crt"), "utf8");
+
+  server = https.createServer(
+    { key: readFileSync(p("srv.key")), cert: readFileSync(p("srv.crt")) },
+    (req, res) => res.end("ok"),
+  );
+  await new Promise((r) => server.listen(0, r));
+  port = server.address().port;
+});
+
+afterAll(() => { server?.close(); });
+
+describe("supplying a certificate authority", () => {
+  it("fails without one, which is the bug this feature fixes", async () => {
+    // The exact error a user reports: "unable to verify the first certificate".
+    await expect(fetch(`https://localhost:${port}/`)).rejects.toThrow(/unable to verify/i);
+  });
+
+  it("succeeds with one", async () => {
+    const res = await fetch(`https://localhost:${port}/`, { tls: { ca: caPem } });
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts several joined by newlines, which is how getCaBundle stores them", async () => {
+    const bundle = [caPem2, caPem].join("\n");
+    const res = await fetch(`https://localhost:${port}/`, { tls: { ca: bundle } });
+    expect(res.status).toBe(200);
+  });
+
+  it("works when the matching authority is not the first in the bundle", async () => {
+    // Order is by name in the database, so the one that matters can be anywhere.
+    const bundle = [caPem2, caPem2, caPem].join("\n");
+    const res = await fetch(`https://localhost:${port}/`, { tls: { ca: bundle } });
+    expect(res.status).toBe(200);
+  });
+
+  it("still fails when only an unrelated authority is supplied", async () => {
+    // Proof the previous tests pass because of the certificate, not because
+    // supplying anything at all disables the check.
+    await expect(
+      fetch(`https://localhost:${port}/`, { tls: { ca: caPem2 } }),
+    ).rejects.toThrow(/unable to verify/i);
+  });
+});
+
+describe("the assumption the whole design rests on", () => {
+  it("adds to the system authorities rather than replacing them", async () => {
+
+    let res;
+    try {
+      res = await fetch("https://api.github.com/", {
+        tls: { ca: caPem },
+        headers: { "User-Agent": "chops-test" },
+      });
+    } catch (err) {
+      // No network is not a failure of the thing being tested, but a TLS error is
+      if (/unable to verify|certificate|self.signed/i.test(err.message)) throw err;
+      console.warn("  skipped: no network");
+      return;
+    }
+    // Any response at all means the handshake succeeded. GitHub answers 200 or 403 depending on rate limits, and either proves the point.
+    expect(res.status).toBeGreaterThan(0);
+  });
+});
+
+describe("reading the certificate a server presents", () => {
+  it("exposes the issuer, which is how the usage list matches", () => {
+    // controllers/trustedCa.js compares this against the stored subjects to say
+    // which clusters depend on which authority.
+    return new Promise((resolve, reject) => {
+      const socket = tls.connect(
+        { host: "localhost", port, ca: [caPem], servername: "localhost" },
+        () => {
+          const cert = socket.getPeerCertificate();
+          socket.end();
+          try {
+            expect(cert.subject.CN).toBe("localhost");
+            expect(cert.issuer.CN).toBe("Test Internal CA");
+            resolve();
+          } catch (e) { reject(e); }
+        },
+      ).on("error", reject);
+    });
+  });
+
+  it("reports whether the supplied authorities validated it", () => {
+    return new Promise((resolve, reject) => {
+      const socket = tls.connect(
+        { host: "localhost", port, ca: [caPem], servername: "localhost" },
+        () => {
+          const authorized = socket.authorized;
+          socket.end();
+          try { expect(authorized).toBe(true); resolve(); } catch (e) { reject(e); }
+        },
+      ).on("error", reject);
+    });
+  });
+});

--- a/tests/no-mocks/trustedCaParse.test.js
+++ b/tests/no-mocks/trustedCaParse.test.js
@@ -1,0 +1,70 @@
+// trustedCaParse.test.js - reading a pasted certificate
+// Contributors - Kathirmoorthy, Kathirdhasan, Praveen
+// Copyright (C) 2026 Quantrail™ Data Private Limited
+
+import { describe, test, expect } from "bun:test";
+import crypto from "node:crypto";
+
+// The rule from services/trustedCa.js. 
+
+function parsePem(pem) {
+  let cert;
+  try {
+    cert = new crypto.X509Certificate(pem);
+  } catch {
+    throw new Error("That does not look like a certificate. Paste the whole PEM block, including the BEGIN and END lines.");
+  }
+  if (!cert.ca) {
+    throw new Error("That is a certificate, but not a certificate authority. You need the CA certificate that signed your server, not the server certificate itself.");
+  }
+  const notAfter = new Date(cert.validTo);
+  if (notAfter.getTime() < Date.now()) {
+    throw new Error(`That certificate authority expired on ${cert.validTo}. An expired one cannot validate anything.`);
+  }
+  return {
+    subject: cert.subject,
+    issuer: cert.issuer,
+    fingerprint: cert.fingerprint256,
+    notBefore: cert.validFrom,
+    notAfter: cert.validTo,
+  };
+}
+
+describe("rejecting things that are not certificates", () => {
+  test("plain text is rejected", () => {
+    expect(() => parsePem("hello")).toThrow(/does not look like a certificate/);
+  });
+
+  test("an empty string is rejected", () => {
+    expect(() => parsePem("")).toThrow();
+  });
+
+  test("PEM markers around rubbish are rejected", () => {
+    // The shape people produce when they copy the wrong half of a file.
+    const fake = "-----BEGIN CERTIFICATE-----\nbm90IGEgY2VydA==\n-----END CERTIFICATE-----";
+    expect(() => parsePem(fake)).toThrow();
+  });
+
+  test("a private key is rejected", () => {
+    // Pasting ca.key instead of ca.crt is an easy mistake and the two files sit
+    // next to each other.
+    const { privateKey } = crypto.generateKeyPairSync("rsa", {
+      modulusLength: 2048,
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    });
+    expect(() => parsePem(privateKey)).toThrow(/does not look like a certificate/);
+  });
+});
+
+describe("the error messages say what to do", () => {
+  test("the not-a-certificate message mentions the BEGIN and END lines", () => {
+    // Someone who pasted only the middle of the file needs to know that.
+    try {
+      parsePem("hello");
+    } catch (err) {
+      expect(err.message).toContain("BEGIN");
+      expect(err.message).toContain("END");
+    }
+  });
+});


### PR DESCRIPTION
## Description
Let CHOps connect to ClickHouse over HTTPS when the certificate was issued by your own internal certificate authority

## Linked Work Item

Closes #

## Checklist (reminder)
- [ ] Unit tests added/updated
- [ ] Documentation updated
- [ ] Linked work item above
- [ ] Peer reviewed
- [ ] Manually self-tested
