### PR TITLE
Fix trusted CA for IP

### DIFF
--- a/src/backend/controllers/trustedCa.js
+++ b/src/backend/controllers/trustedCa.js
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Quantrail™ Data Private Limited
 
 import tls from 'node:tls';
+import net from 'node:net';
 import {
   listTrustedCas,
   addTrustedCa,
@@ -95,13 +96,15 @@ export async function getCaUsage(req, res) {
 }
 
 // Opens a TLS connection and reads the issuer from the certificate presented.
-function peerIssuer(host, port, ca) {
+// SNI (the servername option) is only valid for hostnames, not IP literals,
+// so it is omitted when the cluster host is an IP address.
+export function peerIssuer(host, port, ca) {
   return new Promise((resolve, reject) => {
     const socket = tls.connect(
       {
         host,
         port: port || 8443,
-        servername: host,
+        ...(net.isIP(host) ? {} : { servername: host }),
         ...(ca ? { ca } : {}),
         timeout: 5000,
       },

--- a/tests/net/trustedCaTls.test.js
+++ b/tests/net/trustedCaTls.test.js
@@ -9,6 +9,7 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { peerIssuer } from "../../src/backend/controllers/trustedCa.js";
 
 let caPem, caPem2, server, port;
 
@@ -79,6 +80,65 @@ describe("supplying a certificate authority", () => {
     await expect(
       fetch(`https://localhost:${port}/`, { tls: { ca: caPem2 } }),
     ).rejects.toThrow(/unable to verify/i);
+  });
+});
+
+describe("checking a cluster reached by IP address", () => {
+  let strictServer, strictPort, srvKey, srvCert, caPemIp;
+
+  beforeAll(async () => {
+    const dir = mkdtempSync(join(tmpdir(), "tls-ip-"));
+    const p = (f) => join(dir, f);
+
+    execFileSync("openssl", ["req", "-x509", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", p("ca.key"), "-out", p("ca.crt"), "-days", "365",
+      "-subj", "/CN=Test Internal CA"], { stdio: "ignore" });
+
+    execFileSync("openssl", ["req", "-newkey", "rsa:2048", "-nodes",
+      "-keyout", p("srv.key"), "-out", p("srv.csr"),
+      "-subj", "/CN=127.0.0.1"], { stdio: "ignore" });
+
+    writeFileSync(p("san.ext"), "subjectAltName=IP:127.0.0.1\nbasicConstraints=CA:FALSE\n");
+
+    execFileSync("openssl", ["x509", "-req", "-in", p("srv.csr"),
+      "-CA", p("ca.crt"), "-CAkey", p("ca.key"), "-CAcreateserial",
+      "-out", p("srv.crt"), "-days", "365", "-extfile", p("san.ext")], { stdio: "ignore" });
+
+    srvKey = readFileSync(p("srv.key"));
+    srvCert = readFileSync(p("srv.crt"));
+    caPemIp = readFileSync(p("ca.crt"), "utf8");
+
+    // A server that behaves like a real TLS terminator: RFC 6066 forbids an
+    // IP-literal SNI, so it drops the handshake rather than accept one.
+    strictServer = tls.createServer(
+      { key: srvKey, cert: srvCert, SNICallback: (name, cb) => cb(new Error(`unexpected SNI: ${name}`)) },
+      (socket) => socket.end(),
+    );
+    await new Promise((r) => strictServer.listen(0, "127.0.0.1", r));
+    strictPort = strictServer.address().port;
+  });
+
+  afterAll(() => { strictServer?.close(); });
+
+  it("was unreachable before the fix, because servername was set to the IP", async () => {
+    await expect(new Promise((resolve, reject) => {
+      const socket = tls.connect(
+        { host: "127.0.0.1", port: strictPort, servername: "127.0.0.1", ca: [caPemIp], timeout: 2000 },
+        () => { socket.end(); resolve(); },
+      );
+      socket.on("error", reject);
+      socket.on("timeout", () => { socket.destroy(); reject(new Error("Timed out.")); });
+    })).rejects.toThrow();
+  });
+
+  it("is correctly reported as reachable now that SNI is skipped for IP literals", async () => {
+    const issuer = await peerIssuer("127.0.0.1", strictPort, caPemIp);
+    expect(issuer).toBe("Test Internal CA");
+  });
+
+  it("still sets servername for a hostname, so certificate name matching keeps working", async () => {
+    const issuer = await peerIssuer("localhost", port, caPem);
+    expect(issuer).toBe("Test Internal CA");
   });
 });
 


### PR DESCRIPTION
Root cause: [trustedCa.js:104](vscode-webview://0nq6nfoq1rets8q7c5h5p04s6686o4mtprovs2tk2sobvcue32r0/src/backend/controllers/trustedCa.js#L104) set servername to the cluster host unconditionally. SNI is only valid for DNS hostnames, not IP literals (RFC 6066), so when a cluster's host was an IP address, the TLS terminator on the ClickHouse side rejected the handshake, and the check reported the cluster as unreachable even though a normal connection (which doesn't force SNI to an IP) worked fine.

Fix in [trustedCa.js](vscode-webview://0nq6nfoq1rets8q7c5h5p04s6686o4mtprovs2tk2sobvcue32r0/src/backend/controllers/trustedCa.js#L99-L107): only pass servername when net.isIP(host) says the host is not an IP literal.

Checked for similar issues: searched the whole backend for other manual tls.connect/servername usage and for other raw HTTPS clients. trustedCa.js was the only spot doing manual TLS with an explicit servername; everywhere else (query execution, exports, k8s client) goes through fetch's tls: { ca } option, which already handles IP hosts correctly, matching the report that "TLS connection and CA validation work correctly" elsewhere.

## Linked Work Item
<!-- e.g. Closes #123 -->
Closes #

## Checklist (reminder)
- [ ] Unit tests added/updated
- [ ] Documentation updated
- [ ] Linked work item above
- [ ] Peer reviewed
- [ ] Manually self-tested
