### PR TITLE
Estimate Rows button does not show active/selected state in Export wi…

### DIFF
--- a/src/frontend/components/editor/ExportWizard.jsx
+++ b/src/frontend/components/editor/ExportWizard.jsx
@@ -59,6 +59,14 @@ function recallExport() {
   }
 }
 
+function isThereExport() {
+  return localStorage?.getItem(ACTIVE_EXPORT_KEY) !== null
+}
+
+
+
+console.log(isThereExport())
+
 function defaultFileName(username) {
   const now = new Date();
   const pad = (n) => String(n).padStart(2, "0");
@@ -96,6 +104,8 @@ export default function ExportWizard({ sql, username, onClose }) {
 
   const selectLike = useMemo(() => isSelectLike(sql), [sql]);
   const multiple = useMemo(() => hasMultipleStatements(sql), [sql]);
+
+  const [isEstimated,setIsEstimated] = useState(isThereExport())
 
   // Export does not carry parameter values (see routes/export.js). An OPTIONAL
   // parameter degrades acceptably: its /*[ ]*/ block is dropped and the export
@@ -161,6 +171,7 @@ export default function ExportWizard({ sql, username, onClose }) {
       toast.error(errorMsg);
     } finally {
       setEstimating(false);
+      setIsEstimated(true)
     }
   }
 
@@ -380,9 +391,9 @@ export default function ExportWizard({ sql, username, onClose }) {
                 Close
               </button>
               <button
-                className="btn btn-secondary"
+                className={isEstimated ? "btn btn-primary" : "btn btn-secondary"}
                 onClick={runEstimate}
-                disabled={estimating || blockedByParams}
+                disabled={estimating || blockedByParams || isEstimated}
                 style={{ minWidth: "140px" }}
               >
                 {estimating ? (

--- a/src/frontend/components/editor/QueryEditor.jsx
+++ b/src/frontend/components/editor/QueryEditor.jsx
@@ -87,6 +87,15 @@ const EDITOR_HEIGHT_KEY = "chops_editor_height";
 const EDITOR_HEIGHT_MIN = 90;
 const EDITOR_HEIGHT_DEFAULT = 240;
 
+// A running export outlives the browser:
+const ACTIVE_EXPORT_KEY = "chops_active_export";
+
+function forgetExport() {
+  try {
+    localStorage.removeItem(ACTIVE_EXPORT_KEY);
+  } catch {}
+}
+
 function getEditorHeight() {
   const n = Number(localStorage.getItem(EDITOR_HEIGHT_KEY));
   return Number.isFinite(n) && n >= EDITOR_HEIGHT_MIN
@@ -1217,6 +1226,9 @@ export default function QueryEditor({
       const tabId = runTabId || activeIdRef.current;
       const runTab = tabsRef.current.find((t) => t.id === tabId) || activeTab;
       const rowCap = maxRowsRef.current;
+
+       // removing the older export details in localstorage info
+      forgetExport()
 
       const sql = runTab.sql;
       const paramValues = runTab.params;


### PR DESCRIPTION
## Description
-  Export state persists after running a new query
- Estimate Rows button does not show active/selected state in Export wizard

## Linked Work Item
Closes #411 
Closes #412 

## Checklist (reminder)
- [x] Unit tests added/updated
- [ ] Documentation updated
- [x] Linked work item above
- [ ] Peer reviewed
- [x] Manually self-tested
