### PR TITLE
Update version.json - support for Clickhouse 26.8 LTS

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.2.3",
+  "version": "0.3.0",
   "codename": "chops",
-  "clickhouseVersion": "26.3",
-  "clickhouseCompat": ">=26.3"
+  "clickhouseVersion": "26.8",
+  "clickhouseCompat": ">=26.8"
 }


### PR DESCRIPTION
Tested on Clickhouse 26.8 LTS and with new qurioz

## Description
version bump

## Linked Work Item
<!-- e.g. Closes #123 -->
Closes #

## Checklist (reminder)
- [ ] Unit tests added/updated
- [ ] Documentation updated
- [ ] Linked work item above
- [ ] Peer reviewed
- [ ] Manually self-tested
